### PR TITLE
Implement domain list management

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -31,6 +31,12 @@ CONFIGURATION_PATH = os.getenv('CONFIGURATION_PATH', '.')
 DB_PATH = os.path.join(CONFIGURATION_PATH, 'db')
 if not os.path.isdir(DB_PATH):
     os.mkdir(DB_PATH)
+DASHBOARD_DB_DIR = os.path.dirname(os.path.abspath(__file__))
+DOMAIN_LIST_PATH = os.path.join(DASHBOARD_DB_DIR, 'db', 'list_domains.txt')
+os.makedirs(os.path.dirname(DOMAIN_LIST_PATH), exist_ok=True)
+if not os.path.exists(DOMAIN_LIST_PATH):
+    open(DOMAIN_LIST_PATH, 'a').close()
+    os.chmod(DOMAIN_LIST_PATH, 0o644)
 DASHBOARD_CONF = os.path.join(CONFIGURATION_PATH, 'wg-dashboard.ini')
 UPDATE = None
 app = Flask("WGDashboard", template_folder=os.path.abspath("./static/app/dist"))
@@ -58,7 +64,36 @@ def ResponseObject(status=True, message=None, data=None, status_code = 200) -> F
     })
     response.status_code = status_code
     response.content_type = "application/json"
-    return response       
+    return response
+
+def loadDomains() -> list:
+    domains = []
+    if os.path.exists(DOMAIN_LIST_PATH):
+        with open(DOMAIN_LIST_PATH, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                if '.' in line:
+                    _, dom = line.split('.', 1)
+                else:
+                    dom = line
+                domains.append(dom)
+    return domains
+
+def saveDomains(domains: list[str]):
+    with open(DOMAIN_LIST_PATH, 'w') as f:
+        for i, dom in enumerate(domains, start=1):
+            f.write(f"{i}.{dom}\n")
+    os.chmod(DOMAIN_LIST_PATH, 0o644)
+
+def sanitizeDomain(domain: str) -> str:
+    domain = domain.strip()
+    domain = re.sub(r'^https?://', '', domain)
+    domain = domain.split('/')[0]
+    if domain.startswith('www.'):
+        domain = domain[4:]
+    return domain.lower()
 
 """
 Peer Jobs
@@ -3096,6 +3131,25 @@ def API_Email_PreviewBody():
         return ResponseObject(data=body)
     except Exception as e:
         return ResponseObject(False, message=str(e))
+
+@app.get(f'{APP_PREFIX}/api/getDomains')
+def API_GetDomains():
+    return ResponseObject(data=loadDomains())
+
+@app.post(f'{APP_PREFIX}/api/addDomain')
+def API_AddDomain():
+    data = request.get_json()
+    dom = sanitizeDomain(data.get('domain', ''))
+    if len(dom) == 0:
+        return ResponseObject(False, 'Domain cannot be empty')
+    if not RegexMatch(r"^(?:[a-zA-Z0-9-]{1,63}\.)+[A-Za-z]{2,}$", dom):
+        return ResponseObject(False, 'Invalid domain')
+    domains = loadDomains()
+    if dom in [d.lower() for d in domains]:
+        return ResponseObject(False, 'Domain already exists')
+    domains.append(dom)
+    saveDomains(domains)
+    return ResponseObject(True, data=domains)
 
 @app.get(f'{APP_PREFIX}/api/systemStatus')
 def API_SystemStatus():

--- a/src/static/app/src/components/settingsComponent/domainList.vue
+++ b/src/static/app/src/components/settingsComponent/domainList.vue
@@ -1,0 +1,52 @@
+<script>
+import {DomainStore} from "@/stores/DomainStore.js";
+import LocaleText from "@/components/text/localeText.vue";
+
+export default {
+        name: "domainList",
+        components: {LocaleText},
+        setup(){
+                const store = DomainStore();
+                return {store};
+        },
+        data(){
+                return {
+                        newDomain: ""
+                }
+        },
+        mounted() {
+                this.store.load();
+        },
+        methods:{
+                async add(){
+                        if(this.newDomain.length === 0) return;
+                        await this.store.add(this.newDomain);
+                        this.newDomain = "";
+                }
+        }
+}
+</script>
+
+<template>
+        <div class="card rounded-3">
+                <div class="card-header">
+                        <h6 class="my-2">
+                                <LocaleText t="Domains"></LocaleText>
+                        </h6>
+                </div>
+                <div class="card-body d-flex flex-column gap-2">
+                        <div class="input-group">
+                                <input type="text" class="form-control" v-model="newDomain">
+                                <button class="btn btn-primary" @click="add">
+                                        <LocaleText t="Add"></LocaleText>
+                                </button>
+                        </div>
+                        <ul class="list-group">
+                                <li class="list-group-item" v-for="d in store.domains" :key="d">{{d}}</li>
+                        </ul>
+                </div>
+        </div>
+</template>
+
+<style scoped>
+</style>

--- a/src/static/app/src/stores/DomainStore.js
+++ b/src/static/app/src/stores/DomainStore.js
@@ -1,0 +1,20 @@
+import {defineStore} from "pinia";
+import {fetchGet, fetchPost} from "@/utilities/fetch.js";
+
+export const DomainStore = defineStore('DomainStore', {
+    state: () => ({
+        domains: []
+    }),
+    actions: {
+        async load(){
+            await fetchGet('/api/getDomains', {}, (res) => {
+                if(res.status) this.domains = res.data
+            })
+        },
+        async add(domain){
+            await fetchPost('/api/addDomain', {domain}, (res) => {
+                if(res.status) this.domains = res.data
+            })
+        }
+    }
+});

--- a/src/static/app/src/views/settings.vue
+++ b/src/static/app/src/views/settings.vue
@@ -17,13 +17,15 @@ import DashboardIPPortInput from "@/components/settingsComponent/dashboardIPPort
 import DashboardSettingsWireguardConfigurationAutostart
 	from "@/components/settingsComponent/dashboardSettingsWireguardConfigurationAutostart.vue";
 import DashboardEmailSettings from "@/components/settingsComponent/dashboardEmailSettings.vue";
+import DomainList from "@/components/settingsComponent/domainList.vue";
 
 export default {
 	name: "settings",
 	methods: {ipV46RegexCheck},
 	components: {
-		DashboardEmailSettings,
-		DashboardSettingsWireguardConfigurationAutostart,
+                DashboardEmailSettings,
+                DomainList,
+                DashboardSettingsWireguardConfigurationAutostart,
 		DashboardIPPortInput,
 		DashboardLanguage,
 		LocaleText,
@@ -171,10 +173,11 @@ export default {
 									<AccountSettingsMFA v-if="!this.dashboardConfigurationStore.getActiveCrossServer()"></AccountSettingsMFA>
 								</div>
 							</div>
-							<DashboardAPIKeys></DashboardAPIKeys>
-							<DashboardEmailSettings></DashboardEmailSettings>
-						</div>
-					</Transition>
+                                                        <DashboardAPIKeys></DashboardAPIKeys>
+                                                        <DashboardEmailSettings></DashboardEmailSettings>
+                                                        <DomainList></DomainList>
+                                                </div>
+                                        </Transition>
 					
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- add file for storing domain list
- manage domain list in backend (sanitize, save, load)
- expose `/api/getDomains` and `/api/addDomain`
- display domains in settings via new component
- persist domains in new store

## Testing
- `npm run build`
- `python3 -m py_compile src/dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_685b6069cea4832686d3cbf2899cfd4e