### PR TITLE
Add VPN Domains menu link

### DIFF
--- a/src/static/app/src/components/navbar.vue
+++ b/src/static/app/src/components/navbar.vue
@@ -114,11 +114,16 @@ export default {
 						<RouterLink to="/ping" class="nav-link rounded-3" active-class="active">
 							<LocaleText t="Ping"></LocaleText>
 						</RouterLink></li>
-					<li class="nav-item">
-						<RouterLink to="/traceroute" class="nav-link rounded-3" active-class="active">
-							<LocaleText t="Traceroute"></LocaleText>
-						</RouterLink>
-					</li>
+                                        <li class="nav-item">
+                                                <RouterLink to="/traceroute" class="nav-link rounded-3" active-class="active">
+                                                        <LocaleText t="Traceroute"></LocaleText>
+                                                </RouterLink>
+                                        </li>
+                                        <li class="nav-item">
+                                                <RouterLink to="/vpn-domains" class="nav-link rounded-3" active-class="active">
+                                                        <LocaleText t="VPN Domains"></LocaleText>
+                                                </RouterLink>
+                                        </li>
 				</ul>
 				<hr class="text-body my-2">
 				<ul class="nav flex-column px-2 mb-3">


### PR DESCRIPTION
## Summary
- add link to `/vpn-domains` in sidebar navigation

## Testing
- `npm ci --silent`
- `cd src/static/app && npm ci --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c5d93fbf883269854e4ca2d2b469c